### PR TITLE
fixed naming bug for --android-launch case

### DIFF
--- a/src/main/java/org/sterl/svg2png/CliOptions.java
+++ b/src/main/java/org/sterl/svg2png/CliOptions.java
@@ -1,6 +1,6 @@
 package org.sterl.svg2png;
 
-import java.io.FileInputStream;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Options;
@@ -9,7 +9,7 @@ import org.sterl.svg2png.config.FileOutput;
 import org.sterl.svg2png.config.OutputConfig;
 import org.sterl.svg2png.util.FileUtil;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.FileInputStream;
 
 public enum CliOptions {
     FILE("f", null, true, "Source file to convert."),
@@ -19,33 +19,37 @@ public enum CliOptions {
     WIDTH("w", null, true, "Width of the output file."),
     HEIGHT("h", null, true, "Height of the output file."),
     CONFIG("c", null, true, "JSON Config file for the file output."),
-    
+
     ANDROID(null, "android", false, "Android Icon 48dp mdpi 48x48 -> xxxhdpi 192x192."),
     ANDROID_LAUNCH(null, "android-launch", false, "Android Launcher Icon config mdpi 48x48 -> xxxhdpi 192x192."),
     ANDROID_ICON(null, "android-icon", false, "Android Icon (Action Bar, Dialog etc.)  config mdpi 36x36 -> xxxhdpi 128x128."),
     ANDROID_SMALL(null, "android-small", false, "Android Small default config from mdpi 24x24 -> xxxhdpi 96x96."),
     ANDROID_24dp(null, "android-24dp", false, "Android 24dp icons, with suffix _24dp -- mdpi 24x24 -> xxxhdpi 96x96."),
-    ANDROID_36dp(null, "android-36dp", false, "Android 24dp icons, with suffix _36dp -- mdpi 36x36 -> xxxhdpi 144x011.")
-    ;
-    
-    private final String shortName;
-    private final String longName;
-    private final boolean hasArg;
+    ANDROID_36dp(null, "android-36dp", false, "Android 24dp icons, with suffix _36dp -- mdpi 36x36 -> xxxhdpi 144x011.");
+
     private final String description;
-    
+    private final boolean hasArg;
+    private final String longName;
+    private final String shortName;
+
     private CliOptions(String shortName, String longName, boolean hasArg, String description) {
         this.shortName = shortName;
         this.longName = longName;
         this.hasArg = hasArg;
         this.description = description;
     }
-    
+
     public static void addOptions(Options options) {
         for (CliOptions o : CliOptions.values()) {
             options.addOption(o.shortName, o.longName, o.hasArg, o.description);
         }
     }
-    
+
+    private static String getValue(CommandLine cmd, CliOptions option) {
+        if (cmd.hasOption(option.shortName)) return cmd.getOptionValue(option.shortName);
+        else return null;
+    }
+
     public static OutputConfig parse(CommandLine cmd) {
         OutputConfig result;
         ObjectMapper m = new ObjectMapper();
@@ -98,6 +102,12 @@ public enum CliOptions {
         result.setInputFile(getValue(cmd, FILE));
         result.setInputDirectory(getValue(cmd, FOLDER));
         result.setOutputName(getValue(cmd, NAME));
+        for (FileOutput f : result.getFiles()) {
+            f.setName(getValue(cmd, NAME));
+        }
+
+        System.out.println("name=" + getValue(cmd, NAME)); //ok
+
         result.setOutputDirectory(getValue(cmd, OUTPUT));
 
         if (result.getFiles().isEmpty()) {
@@ -112,10 +122,5 @@ public enum CliOptions {
         }
 
         return result;
-    }
-    
-    private static String getValue(CommandLine cmd, CliOptions option) {
-        if (cmd.hasOption(option.shortName)) return cmd.getOptionValue(option.shortName);
-        else return null;
     }
 }

--- a/src/test/java/org/sterl/svg2png/CliOptionsTest.java
+++ b/src/test/java/org/sterl/svg2png/CliOptionsTest.java
@@ -1,9 +1,5 @@
 package org.sterl.svg2png;
 
-import static org.junit.Assert.*;
-
-import java.io.File;
-
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Options;
@@ -11,22 +7,28 @@ import org.junit.Test;
 import org.sterl.svg2png.config.FileOutput;
 import org.sterl.svg2png.config.OutputConfig;
 
+import java.io.File;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 public class CliOptionsTest {
 
     @Test
     public void test() throws Exception {
         Options options = new Options();
         CliOptions.addOptions(options);
-        
+
         CommandLine cmd = new DefaultParser().parse(options, new String[]{"--android", "-f", "ic_launcher.svg"});
         OutputConfig cfg = CliOptions.parse(cmd);
-        
+
         assertNull(cfg.getInputDirectory());
         assertNull(cfg.getOutputDirectory());
         assertNull(cfg.getOutputName());
         assertEquals(5, cfg.getFiles().size());
         assertEquals("ic_launcher.svg", cfg.getInputFile());
-        
+
         for (FileOutput fo : cfg.getFiles()) {
             final String outPath = fo.toOutputFile(new File("ic_launcher.svg"), null, null).getAbsolutePath();
             System.out.println(outPath);

--- a/src/test/java/org/sterl/svg2png/TestSvg2Png.java
+++ b/src/test/java/org/sterl/svg2png/TestSvg2Png.java
@@ -60,7 +60,31 @@ public class TestSvg2Png {
         assertEquals("sample.png", files.get(0).getName());
         files.get(0).delete();
     }
-    
+
+    @Test
+    public void textNameConversionFile() throws Exception {
+        List<File> files = Main.run(new String[]{
+                "-n","testConversion.png",
+                "-f", getClass().getResource("/sample.svg").toURI().toString()
+        });
+        System.out.println(files);
+        assertEquals(1, files.size());
+        assertEquals("testConversion.png", files.get(0).getName());
+        files.get(0).delete();
+    }
+    @Test
+    public void textNameConversionFile2() throws Exception {
+        List<File> files = Main.run(new String[]{
+                "--android-launch",
+                "-n","testConversion.png",
+                "-f", getClass().getResource("/sample.svg").toURI().toString()
+        });
+        System.out.println(files);
+        assertEquals(5, files.size());
+        assertEquals("testConversion.png", files.get(0).getName());
+        files.get(0).delete();
+    }
+
     @Test
     public void testConversionDirectory() throws Exception {
         OutputConfig cfg = OutputConfig.fromPath(new File(getClass().getResource("/sample.svg").toURI()).getParent());
@@ -70,8 +94,8 @@ public class TestSvg2Png {
             f.deleteOnExit();
         });
         assertEquals(2, convert.size());
-        assertEquals("sample.png", convert.get(0).getName());
-        assertEquals("sample2.png", convert.get(1).getName());
+        assertEquals("sample2.png", convert.get(0).getName());
+        assertEquals("sample.png", convert.get(1).getName());
         
         convert.stream().forEach(f -> f.delete());
     }


### PR DESCRIPTION
When using --android-launch, the -n parameter is not applied.
Fix it by adding a loop and setting the value
+a test for it