### PR TITLE
Security Fix for SSRF - huntr.dev

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>
-        <batik.version>1.11</batik.version>
+        <batik.version>1.14</batik.version>
     </properties>
     <dependencies>
         <dependency>
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>org.apache.xmlgraphics</groupId>
             <artifactId>xmlgraphics-commons</artifactId>
-            <version>2.3</version>
+            <version>2.6</version>
         </dependency>
         
         <dependency>
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.10.0</version>
+            <version>2.10.5.1</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/src/main/java/org/sterl/svg2png/Svg2Png.java
+++ b/src/main/java/org/sterl/svg2png/Svg2Png.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+import org.apache.batik.transcoder.SVGAbstractTranscoder;
 import org.apache.batik.transcoder.TranscoderException;
 import org.apache.batik.transcoder.TranscoderInput;
 import org.apache.batik.transcoder.TranscoderOutput;

--- a/src/main/java/org/sterl/svg2png/Svg2Png.java
+++ b/src/main/java/org/sterl/svg2png/Svg2Png.java
@@ -47,6 +47,7 @@ public class Svg2Png {
     private static List<File> convertFile(File input, OutputConfig cfg) throws IOException, TranscoderException, FileNotFoundException {
         final TranscoderInput ti = new TranscoderInput(input.toURI().toString());
         final PNGTranscoder t = new PNGTranscoder();
+        t.addTranscodingHint(SVGAbstractTranscoder.KEY_ALLOW_EXTERNAL_RESOURCES, false); // Disable XXE
         final List<File> generated = new ArrayList<>();
         
         final String inputPath = input.getParent();

--- a/src/test/resources/svg-with-external-resource.svg
+++ b/src/test/resources/svg-with-external-resource.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="overflow: hidden; position: relative;" width="300" height="200">
+  <image x="10" y="10" width="276" height="110" xlink:href="http://localhost:8080/svg" stroke-width="1" id="image3204" />
+  <rect x="0" y="150" height="10" width="300" style="fill: black"/>
+</svg>


### PR DESCRIPTION
@doshmajhan (https://huntr.dev/users/doshmajhan) has fixed a potential SSRF vulnerability in your repository 🔨. For more information, visit our website (https://huntr.dev/) or click the bounty URL below...

Q | A
Version Affected | *
Bug Fix | YES
Original Pull Request | https://github.com/418sec/svg2png-1/pull/1

If you are happy with this disclosure, we would love to get a CVE assigned to the vulnerability. Feel free to credit @doshmajhan, the discloser found in the bounty URL (below) and @huntr-helper.

### User Comments:

### 📊 Metadata *

#### Bounty URL: https://huntr.dev/bounties/1-other-svg2png/

### ⚙️ Description *
The `svg2png` CLI tool will convert SVGs to PNGs and in the process, evaluate any external resources in the provided SVG image, leading to a Server Side Request Forgey vulnerability.
```

### 💻 Technical Description *

The `PNGTranscoder` class used to transcode the SVG to a PNG will process external resources in the SVG file leading to an SSRF vulnerability. This can be disabled by adding a transcoder hint to the created transcoder:
```
final PNGTranscoder t = new PNGTranscoder();
t.addTranscodingHint(SVGAbstractTranscoder.KEY_ALLOW_EXTERNAL_RESOURCES, false);
```

I've also bumped the versions of the `batik`, `apache-xmlgraphics` and `jackson` dependencies as they contain main security patches and bug fixes.

### 🐛 Proof of Concept (PoC) *

The following SVG image when process will make a call out to `http://localhost:8080/svg. This is define in the `xlink:href` attribute:
```
<?xml version="1.0" encoding="UTF-8" standalone="no"?>
<svg xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="overflow: hidden; position: relative;" width="300" height="200">
  <image x="10" y="10" width="276" height="110" xlink:href="http://localhost:8080/svg" stroke-width="1" id="image3204" />
  <rect x="0" y="150" height="10" width="300" style="fill: black"/>
</svg>
```

### 🔥 Proof of Fix (PoF) *

After fix:
```
❯ ./svg2png exploit.svg 
                             
....

*** Error: org.apache.batik.transcoder.TranscoderException: null
Enclosed Exception:
The security settings do not allow any external resources to be referenced from the document ***
Input File: /home/doshmajhan/bugbounty/huntr-fixes/svg2png-1/target/exploit.svg
Output Directory: /home/doshmajhan/bugbounty/huntr-fixes/svg2png-1/target/.

```

### 👍 User Acceptance Testing (UAT)

The newly added test `testConversionOfFileWithExternalResourceFails` will prevent regressions.